### PR TITLE
update navbar support link to zendesk

### DIFF
--- a/content/nav/bar/nav.md
+++ b/content/nav/bar/nav.md
@@ -7,5 +7,5 @@ navOpts:
 - Support
 links :
 - /partner/
-- "https://storjlabs.atlassian.net/servicedesk/customer/portals"
+- "https://support.tardigrade.io/hc/en-us"
 ---

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -36,7 +36,7 @@
             </a>
         </li>
         <li class="nav-item mr-3 active">
-            <a class="nav-link" href="https://storjlabs.atlassian.net/servicedesk/customer/portals">
+            <a class="nav-link" href="https://support.tardigrade.io/hc/en-us">
                 <p class="navlink">Support
                 <span class="sr-only">(current)</span>
                 </p>


### PR DESCRIPTION
The purpose of this PR is to update our nav bar support link to point at the zen desk portal instead of the Jira portal because the Jira portal is being deprecated.