### PR TITLE
Add trusted Satellite list

### DIFF
--- a/static/trusted-satellites
+++ b/static/trusted-satellites
@@ -1,0 +1,4 @@
+12EayRS2V1kEsWESU9QMRseFhdxYxKicsiFmxrsLZHeLUtdps3S@us-central-1.tardigrade.io:7777
+12L9ZFwhzVpuEKMUNUqkaTLGzwY9G24tbiigLiXpmZWKwmcNDDs@europe-west-1.tardigrade.io:7777
+121RTSDpyNZVcEU84Ticf2L1ntiuUimbWgfATz21tuvgk3vzoA6@asia-east-1.tardigrade.io:7777
+118UWpMCHzs6CvSgWd9BfFVjw5K9pZbJjkfZJexMtSkmKxvvAW@satellite.stefan-benten.de:7777


### PR DESCRIPTION
This PR adds a static trusted satellite list used as the default source of trust for Storage Nodes.