### PR TITLE
netlify: Add some good security headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -35,3 +35,9 @@ HUGO_ENABLEGITINFO = "true"
   to = "https://adoring-borg-aad42e.netlify.com/:splat"
   status = 200
   force = true
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "deny"
+    Strict-Transport-Security = "max-age=300; includeSubDomains"


### PR DESCRIPTION
Add a couple of headers to be served with all the pages of the site for
denying to load the site in an iframe and to indicate to the browser
that the site has always to be accessed through HTTPS.