### PR TITLE
Typo in heading

### DIFF
--- a/content/home/halfPrice/halfPrice.md
+++ b/content/home/halfPrice/halfPrice.md
@@ -1,5 +1,5 @@
 ---
-heading: "Straight-Forwarding Pricing"
+heading: "Straight-Forward Pricing"
 col1Heading: "Storage"
 col1Image: "/img/tar-ico-cloud.png"
 col1Amount: "$0.01"


### PR DESCRIPTION
It should be "straight-forward"