### PR TITLE
name logic

### DIFF
--- a/layouts/filezilla/single.html
+++ b/layouts/filezilla/single.html
@@ -8,7 +8,7 @@
 		{{partial "secondNav" (dict "logo" "/img/tar-logo-whit-horizontal.svg" )}}
 	</header>
 	{{partial "single-connector/connectorHero" (dict "connectorInfo" "partner19" "context" . "page" $.Site.GetPage )}}
-	{{ partial "single-connector/connectorContent" (dict "connectorInfo" "partner19" "context" . "page" $.Site.GetPage )}}
+	{{ partial "single-connector/connectorContent" (dict "name" "FileZilla" "connectorInfo" "partner19" "context" . "page" $.Site.GetPage )}}
 	<footer>
 		{{partial "footer" . }}
 	</footer>

--- a/layouts/partials/single-connector/connectorContent.html
+++ b/layouts/partials/single-connector/connectorContent.html
@@ -60,7 +60,7 @@
 					<div class="row single-connector__main__wrapper">
 						<div class="spacer60"></div>
 						<div class="row">
-							<h3 class="single-connector__main__header">Why Tardigrade is Perfect for Filezilla</h3>
+							<h3 class="single-connector__main__header">Why Tardigrade is Perfect for {{.name}}</h3>
 						</div>
 						{{ range where .context.Site.Pages ".Params.class" "connector-content"}}
 						<div class="col-sm-12 col-md-6 single-connector__main__section">


### PR DESCRIPTION
- logic for adding the connector names to their pages
- there was also a typo in the filezilla name